### PR TITLE
Integrate Chainlit MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,13 @@ After the scan results are available, access the service at [http://localhost](h
 
 For more detailed examples and use cases, see our [Usage Guide](chainlit.md).
 
+### MCP Support
+
+The agent now integrates the new **MCP** tool from Chainlit. When available, it
+processes user messages before the reasoning step to enhance responses. Details
+of our implementation and how it differs from Chainlit's built‑in version can be
+found in [MCP Integration](docs/MCP_Comparison.md).
+
 ## License
 
 This project is licensed under the [Trend Micro Community License](LICENSE).

--- a/docs/Development.md
+++ b/docs/Development.md
@@ -41,4 +41,8 @@ Start the Chainlit application:
 chainlit run src/core/app.py
 ```
 
+The latest version of Chainlit supports the **MCP** tool. Our implementation uses
+it to enrich user queries before the reasoning step. See [MCP Integration](MCP_Comparison.md)
+for more details.
+
 The application should now be running at http://localhost:8000

--- a/docs/MCP_Comparison.md
+++ b/docs/MCP_Comparison.md
@@ -1,0 +1,6 @@
+# MCP Integration
+
+This project uses a lightweight custom MCP implementation to enrich the user query before reasoning.
+
+Chainlit\'s latest version provides a built‑in MCP module that can run external tools. When available, the agent invokes the Chainlit MCP to process the latest user message. If the Chainlit MCP is not present, a local fallback defined in `src/utils/mcp.py` simply echoes the input. The enriched content is added as a new message before the reasoning step, allowing the LLM to generate more detailed answers.
+

--- a/src/utils/mcp.py
+++ b/src/utils/mcp.py
@@ -1,0 +1,7 @@
+"""Simple MCP utility module."""
+
+
+def run_custom_mcp(content: str) -> str:
+    """Return processed content for the MCP fallback."""
+    # Placeholder for custom processing. Currently it simply echoes the input.
+    return content

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -1,0 +1,19 @@
+import pytest
+from langchain_core.messages import HumanMessage
+
+from src.utils.mcp import run_custom_mcp
+from src.core.app import apply_mcp, AgentState
+
+
+def test_run_custom_mcp_echo():
+    assert run_custom_mcp("hello") == "hello"
+
+
+@pytest.mark.asyncio
+async def test_apply_mcp_without_chainlit(monkeypatch):
+    import chainlit as cl
+    monkeypatch.setattr(cl, "mcp", None, raising=False)
+    state = AgentState(messages=[HumanMessage(content="hi")])
+    result = await apply_mcp(state)
+    assert len(result["messages"]) == 2
+    assert result["messages"][1].content == "hi"


### PR DESCRIPTION
## Summary
- document MCP integration
- describe MCP in development guide
- provide lightweight fallback for MCP
- wire MCP tool before reasoning node
- add basic tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'langchain_core')*